### PR TITLE
ensure fan vent is properly subtracted

### DIFF
--- a/case/case.scad
+++ b/case/case.scad
@@ -69,21 +69,22 @@ module pcbCutout() {
 module fanCutOut() {
   fan_outer_radius = 9;
   fan_inner_radius = 6;
+  epsilon = 1;
 
-  translate([PM25_X, BIG_VENT_CENTER, PM25_Z / 2])
+  translate([PM25_X - epsilon, BIG_VENT_CENTER, PM25_Z / 2])
     rotate([0, 90, 0])
     difference() {
       $fn = 90;
-      linear_extrude(WALL_SIZE)
+      linear_extrude(WALL_SIZE + epsilon)
         circle(r = fan_outer_radius);
 
-      linear_extrude(WALL_SIZE)
+      linear_extrude(WALL_SIZE + epsilon)
         circle(r = fan_inner_radius);
 
-      linear_extrude(WALL_SIZE)
+      linear_extrude(WALL_SIZE + epsilon)
         square(size = [3.1, fan_outer_radius * 2], center = true);
 
-      linear_extrude(WALL_SIZE)
+      linear_extrude(WALL_SIZE + epsilon)
         square(size = [fan_outer_radius * 2, 1.6], center = true);
     }
 }


### PR DESCRIPTION
Previously, the fan vent subtraction was leaving a thin layer on the
  wall, but we want a hole.

I _think_ it might have something to do with [this](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/The_OpenSCAD_Language#difference) section of the docs, namely:

> It is mandatory that surfaces that are to be removed by a difference
> operation have an overlap, and that the negative piece being removed
> extends fully outside of the volume it is removing that surface from.

Previously, what I _think_ was happening (I know next to nothing about
  OpenSCAD / CAD in general so I might be wrong) was that the surface
  being removed did not extend fully outside of the wall.